### PR TITLE
fix: #43 food card responsive

### DIFF
--- a/components/Carousel/Card/CardCarousel.tsx
+++ b/components/Carousel/Card/CardCarousel.tsx
@@ -21,20 +21,8 @@ type Props = {
 
   /** Card carousel을 움직이는 오른쪽 버튼 */
   next: React.RefObject<HTMLDivElement>;
-
-  /** Carousel에 보여지는 카드 수 */
-  slidesPerView?: number;
-
-  /** Carousel에서 다음 버튼을 누르면 넘어가는 카드 수 */
-  slidesPerGroup?: number;
 };
-const CardCarousel = ({
-  cards,
-  prev,
-  next,
-  slidesPerView = 4,
-  slidesPerGroup = 4
-}: Props) => {
+const CardCarousel = ({ cards, prev, next }: Props) => {
   return (
     <Swiper
       navigation={{
@@ -53,9 +41,20 @@ const CardCarousel = ({
       }}
       modules={[FreeMode, Navigation]}
       spaceBetween={20}
-      slidesPerView={slidesPerView}
-      slidesPerGroup={slidesPerGroup}
+      slidesPerView={1.5}
+      slidesPerGroup={1}
       freeMode
+      breakpoints={{
+        768: {
+          slidesPerView: 3,
+          slidesPerGroup: 3
+        },
+        1440: {
+          slidesPerView: 4,
+          slidesPerGroup: 4,
+          freeMode: false
+        }
+      }}
       loop
     >
       {cards.map((card, idx) => (

--- a/components/Carousel/Card/CardCarousel.tsx
+++ b/components/Carousel/Card/CardCarousel.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 
 import FoodContentCard from '@/components/FoodContentCard';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import { Navigation } from 'swiper';
+import { FreeMode, Navigation } from 'swiper';
 import 'swiper/css/navigation';
+import 'swiper/css/free-mode';
+
 import CreatorProfile from '@/components/FoodContentCard/Footer/CreatorProfile';
 import { VideoInformation } from '@/types/youtube';
 import timeFormatter from '@/utils/timeFormatter';
@@ -16,11 +18,23 @@ type Props = {
 
   /** Card carousel을 움직이는 왼쪽 버튼 */
   prev: React.RefObject<HTMLDivElement>;
-  /** Card carousel을 움직이는 오른쪽 버튼 */
 
+  /** Card carousel을 움직이는 오른쪽 버튼 */
   next: React.RefObject<HTMLDivElement>;
+
+  /** Carousel에 보여지는 카드 수 */
+  slidesPerView?: number;
+
+  /** Carousel에서 다음 버튼을 누르면 넘어가는 카드 수 */
+  slidesPerGroup?: number;
 };
-const CardCarousel = ({ cards, prev, next }: Props) => {
+const CardCarousel = ({
+  cards,
+  prev,
+  next,
+  slidesPerView = 4,
+  slidesPerGroup = 4
+}: Props) => {
   return (
     <Swiper
       navigation={{
@@ -37,10 +51,11 @@ const CardCarousel = ({ cards, prev, next }: Props) => {
           swiper.params.navigation.nextEl = next.current;
         }
       }}
-      modules={[Navigation]}
+      modules={[FreeMode, Navigation]}
       spaceBetween={20}
-      slidesPerView={4}
-      slidesPerGroup={4}
+      slidesPerView={slidesPerView}
+      slidesPerGroup={slidesPerGroup}
+      freeMode
       loop
     >
       {cards.map((card, idx) => (

--- a/components/Carousel/Card/CardCarouselContainer.tsx
+++ b/components/Carousel/Card/CardCarouselContainer.tsx
@@ -5,6 +5,7 @@ import CardCarousel from './CardCarousel';
 import ArrowRight from '@/public/svg/arrow-right.svg';
 import ArrowLeft from '@/public/svg/arrow-left.svg';
 import { YoutubeCategory } from '@/types/youtube';
+import { useScreenType } from '@/hook/useScreen';
 export type CardCarouselContainerProps = {
   /**
    * 카드에 들어가는 컨텐츠
@@ -15,6 +16,13 @@ export type CardCarouselContainerProps = {
 const CardCarouselContainer = ({ contents }: CardCarouselContainerProps) => {
   const prevButtonRef = useRef<HTMLDivElement>(null);
   const nextButtonRef = useRef<HTMLDivElement>(null);
+
+  const screenType = useScreenType();
+  // NOTE: 반응형으로 카드의 수가 달라짐
+  const slidesPerView =
+    screenType === 'phone' ? 1.5 : screenType === 'tablet' ? 3 : 4;
+  const slidesPerGroup =
+    screenType === 'phone' ? 1 : screenType === 'tablet' ? 3 : 4;
 
   return (
     <CarouselContainer>
@@ -33,6 +41,8 @@ const CardCarouselContainer = ({ contents }: CardCarouselContainerProps) => {
         cards={contents.data}
         prev={prevButtonRef}
         next={nextButtonRef}
+        slidesPerView={slidesPerView}
+        slidesPerGroup={slidesPerGroup}
       />
     </CarouselContainer>
   );
@@ -41,8 +51,15 @@ const CardCarouselContainer = ({ contents }: CardCarouselContainerProps) => {
 export default CardCarouselContainer;
 
 const CarouselContainer = styled.div`
-  max-width: 78.75rem;
+  max-width: 80rem;
   margin: auto;
+
+  width: 100%;
+  padding: 0 1.25rem;
+
+  ${({ theme }) => theme.screen.desktop} {
+    width: auto;
+  }
 `;
 
 const TitleWrapper = styled.div`

--- a/components/Carousel/Card/CardCarouselContainer.tsx
+++ b/components/Carousel/Card/CardCarouselContainer.tsx
@@ -63,10 +63,14 @@ const CarouselContainer = styled.div`
 `;
 
 const TitleWrapper = styled.div`
-  padding: 2.5rem 0;
+  padding: 1.5rem 0rem 0.75rem 0rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
+
+  ${({ theme }) => theme.screen.desktop} {
+    padding: 2rem 0;
+  }
 `;
 
 const ArrowButton = styled.div`
@@ -90,6 +94,10 @@ const SwiperButtonWrapper = styled.div`
 `;
 
 const CategoryTitle = styled.h2`
-  ${({ theme }) => theme.font.headLine.md};
   color: ${({ theme }) => theme.colors.white[0]};
+  ${({ theme }) => theme.font.title.sm};
+
+  ${({ theme }) => theme.screen.desktop} {
+    ${({ theme }) => theme.font.headLine.md};
+  }
 `;

--- a/components/Carousel/Card/CardCarouselContainer.tsx
+++ b/components/Carousel/Card/CardCarouselContainer.tsx
@@ -5,7 +5,6 @@ import CardCarousel from './CardCarousel';
 import ArrowRight from '@/public/svg/arrow-right.svg';
 import ArrowLeft from '@/public/svg/arrow-left.svg';
 import { YoutubeCategory } from '@/types/youtube';
-import { useScreenType } from '@/hook/useScreen';
 export type CardCarouselContainerProps = {
   /**
    * 카드에 들어가는 컨텐츠
@@ -16,13 +15,6 @@ export type CardCarouselContainerProps = {
 const CardCarouselContainer = ({ contents }: CardCarouselContainerProps) => {
   const prevButtonRef = useRef<HTMLDivElement>(null);
   const nextButtonRef = useRef<HTMLDivElement>(null);
-
-  const screenType = useScreenType();
-  // NOTE: 반응형으로 카드의 수가 달라짐
-  const slidesPerView =
-    screenType === 'phone' ? 1.5 : screenType === 'tablet' ? 3 : 4;
-  const slidesPerGroup =
-    screenType === 'phone' ? 1 : screenType === 'tablet' ? 3 : 4;
 
   return (
     <CarouselContainer>
@@ -41,8 +33,6 @@ const CardCarouselContainer = ({ contents }: CardCarouselContainerProps) => {
         cards={contents.data}
         prev={prevButtonRef}
         next={nextButtonRef}
-        slidesPerView={slidesPerView}
-        slidesPerGroup={slidesPerGroup}
       />
     </CarouselContainer>
   );

--- a/components/FoodContentCard/Body/index.tsx
+++ b/components/FoodContentCard/Body/index.tsx
@@ -13,11 +13,20 @@ const Title = styled.h3`
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  ${({ theme }) => theme.font.title.sm};
+
+  ${({ theme }) => theme.font.label.lg}
+
+  ${({ theme }) => theme.screen.desktop} {
+    ${({ theme }) => theme.font.title.sm};
+  }
 `;
 
 const Subtitle = styled.h5`
   ${({ theme }) => theme.font.body.md};
+
+  ${({ theme }) => theme.screen.desktop} {
+    ${({ theme }) => theme.font.label.lg};
+  }
 `;
 
 type Props = {

--- a/components/FoodContentCard/Layout/index.tsx
+++ b/components/FoodContentCard/Layout/index.tsx
@@ -2,8 +2,7 @@ import styled from '@emotion/styled';
 import { PropsWithChildren } from 'react';
 
 const Layout = styled.article`
-  width: 18.75rem;
-  height: 19.5rem;
+  // Responsive 한 카드를 위한 width, height 설정 제거
 `;
 
 const FoodContentCardLayout = ({ children }: PropsWithChildren) => {

--- a/components/FoodContentCard/Layout/index.tsx
+++ b/components/FoodContentCard/Layout/index.tsx
@@ -3,6 +3,12 @@ import { PropsWithChildren } from 'react';
 
 const Layout = styled.article`
   // Responsive 한 카드를 위한 width, height 설정 제거
+
+  padding-bottom: 1.25rem;
+
+  ${({ theme }) => theme.screen.desktop} {
+    padding-bottom: 2rem;
+  }
 `;
 
 const FoodContentCardLayout = ({ children }: PropsWithChildren) => {

--- a/hook/useScreen.ts
+++ b/hook/useScreen.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+
+type ScreenMode = 'phone' | 'tablet' | 'desktop';
+
+const useScreen = (mode: ScreenMode) => {
+  const [screenSize, setScreenSize] = useState('');
+
+  const handleResize = () => {
+    const { innerWidth } = window;
+    let currentScreenSize = '';
+
+    if (innerWidth < 768) {
+      currentScreenSize = 'phone';
+    } else if (innerWidth < 1440) {
+      currentScreenSize = 'tablet';
+    } else {
+      currentScreenSize = 'desktop';
+    }
+
+    setScreenSize(currentScreenSize);
+  };
+
+  useEffect(() => {
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return screenSize === mode;
+};
+
+export const useScreenType = () => {
+  const [screenSize, setScreenSize] = useState<number>();
+
+  const handleResize = () => {
+    const { innerWidth } = window;
+
+    setScreenSize(innerWidth);
+  };
+
+  useEffect(() => {
+    if (!screenSize) setScreenSize(window.innerWidth);
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  if (!screenSize) return;
+  if (screenSize < 768) {
+    return 'phone';
+  } else if (screenSize < 1440) {
+    return 'tablet';
+  } else {
+    return 'desktop';
+  }
+};
+
+export default useScreen;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -52,5 +52,9 @@ export const MainContainer = styled.div`
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  gap: 4rem;
+  gap: 0;
+
+  ${({ theme }) => theme.screen.desktop} {
+    gap: 1.5rem;
+  }
 `;


### PR DESCRIPTION
## 🏆 관련 이슈
<!-- close #이슈번호 -->
close #43 

## 🎉 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- mobile, tablet, desktop 시 Food card content 사이즈 Carousel 변경
- mobile, tablet에서는 양 옆으로 스와이프도 자유자재로 가능하도록 구현 (freemode)
  - 혹시 몰라서 우선 navigation 버튼도 남긴 상태..

## 📷 UI 스크린샷


<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img width="402" alt="Screen Shot 2023-07-01 at 10 53 29 AM" src="https://github.com/cancook/cancook-frontend/assets/50029346/c6f78e78-5e14-40b7-b9c2-00c968c07b65">
<img width="698" alt="Screen Shot 2023-07-01 at 10 53 35 AM" src="https://github.com/cancook/cancook-frontend/assets/50029346/5e5a35ca-55b0-4eb3-8567-00d27fcd6237">
<img width="1206" alt="Screen Shot 2023-07-01 at 10 53 47 AM" src="https://github.com/cancook/cancook-frontend/assets/50029346/93ae3568-8592-400b-a7b3-4dc9fbcc3673">

## 🎸 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
